### PR TITLE
Preserve the NILMbench project URL

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -4,6 +4,7 @@ project:
   resources:
     - images/**  # Ensures all images are copied
     - events/acm-summer-2025/
+    - nilmbench/
 
 website:
   title: "Sustainability Lab"

--- a/nilmbench/index.html
+++ b/nilmbench/index.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex">
+  <meta http-equiv="refresh" content="0; url=https://nilmtk.github.io/nilmbench/">
+  <link rel="canonical" href="https://nilmtk.github.io/nilmbench/">
+  <title>NILMbench has moved</title>
+  <script>
+    const relativePath = window.location.pathname.replace(/^\/nilmbench\/?/, "");
+    const destination = new URL(
+      `https://nilmtk.github.io/nilmbench/${relativePath}`
+    );
+    destination.search = window.location.search;
+    destination.hash = window.location.hash;
+    window.location.replace(destination);
+  </script>
+  <style>
+    body {
+      max-width: 42rem;
+      margin: 15vh auto;
+      padding: 0 1.5rem;
+      color: #18332c;
+      background: #f4f1e8;
+      font: 1.1rem/1.6 system-ui, sans-serif;
+    }
+    a { color: #0c6752; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>NILMbench has moved</h1>
+    <p>
+      Continue to the maintained project page at
+      <a href="https://nilmtk.github.io/nilmbench/">nilmtk.github.io/nilmbench</a>.
+    </p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## What changed

- publish a static redirect at `sustainability-lab.github.io/nilmbench/`
- preserve query strings, fragments, and subpaths where possible
- include the redirect directory in the existing Quarto resource pipeline

## Why

NILMbench is being prepared for transfer from `sustainability-lab` to the `nilmtk` organization. GitHub redirects transferred repository URLs, but it does not redirect the repository's GitHub Pages URL. This small precursor keeps the paper and existing external links useful after the ownership transfer.

## Verification

- the full Quarto site rendered successfully
- the rendered `docs/nilmbench/index.html` is byte-identical to the source redirect
- `git diff --check` passed

